### PR TITLE
chore/rename done method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6476,7 +6476,7 @@
     },
     "packages/core": {
       "name": "@prtcl/plonk-core",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -6511,10 +6511,10 @@
       }
     },
     "packages/plonk": {
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
-        "@prtcl/plonk-core": "^1.0.0-alpha.2",
+        "@prtcl/plonk-core": "^1.0.0-alpha.3",
         "@prtcl/plonk-hooks": "^1.0.0-alpha.2",
         "@prtcl/plonk-utils": "^1.0.0-alpha.2"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prtcl/plonk-core",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "Tiny library that provides timers, envelopes, and random generators",
   "author": "Cory O'Brien <cory@prtcl.cc>",
   "license": "MIT",

--- a/packages/core/src/Env.ts
+++ b/packages/core/src/Env.ts
@@ -107,14 +107,14 @@ export default class Env {
     });
   }
 
-  hasFinished() {
+  done() {
     return this.state.duration <= this.state.totalElapsed;
   }
 
   value() {
     const { to, value } = this.state;
 
-    if (this.hasFinished()) {
+    if (this.done()) {
       return to;
     }
 
@@ -122,7 +122,7 @@ export default class Env {
   }
 
   next() {
-    if (this.hasFinished()) {
+    if (this.done()) {
       return this.value();
     }
 

--- a/packages/core/src/__tests__/Env.test.ts
+++ b/packages/core/src/__tests__/Env.test.ts
@@ -18,7 +18,7 @@ describe('Env', () => {
 
       loops += 1;
 
-      if (e.hasFinished()) {
+      if (e.done()) {
         clearInterval(timerId);
         expect(e.value()).toEqual(1);
       }
@@ -37,7 +37,7 @@ describe('Env', () => {
 
       expect(val).toBeLessThan(prev);
 
-      if (e.hasFinished()) {
+      if (e.done()) {
         clearInterval(timerId);
         expect(e.value()).toEqual(0);
       }
@@ -56,11 +56,11 @@ describe('Env', () => {
     });
 
     expect(e.value()).toEqual(100);
-    expect(e.hasFinished()).toEqual(false);
+    expect(e.done()).toEqual(false);
 
     setTimeout(() => {
       expect(e.next()).toEqual(500);
-      expect(e.hasFinished()).toEqual(true);
+      expect(e.done()).toEqual(true);
 
       done();
     }, 25);

--- a/packages/core/src/__tests__/Metro.test.ts
+++ b/packages/core/src/__tests__/Metro.test.ts
@@ -15,7 +15,7 @@ describe('Metro', () => {
             state.iterations * 30,
           );
           expect(state.tickInterval).toBeGreaterThanOrEqual(30);
-          expect(state.tickInterval).toBeLessThanOrEqual(50);
+          expect(state.tickInterval).toBeLessThanOrEqual(55);
         }
 
         expect(state.prev).toBeGreaterThanOrEqual(start);
@@ -45,10 +45,10 @@ describe('Metro', () => {
           expect(state.tickInterval).toEqual(0);
         } else if (state.iterations >= 5) {
           expect(state.tickInterval).toBeGreaterThanOrEqual(50);
-          expect(state.tickInterval).toBeLessThanOrEqual(70);
+          expect(state.tickInterval).toBeLessThanOrEqual(75);
         } else {
           expect(state.tickInterval).toBeGreaterThanOrEqual(30);
-          expect(state.tickInterval).toBeLessThanOrEqual(50);
+          expect(state.tickInterval).toBeLessThanOrEqual(55);
         }
 
         if (state.iterations === 10) {

--- a/packages/plonk/package.json
+++ b/packages/plonk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plonk",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Tiny library that provides timers, envelopes, and random generators",
   "author": "Cory O'Brien <cory@prtcl.cc>",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "clean": "rm -rf dist | true"
   },
   "dependencies": {
-    "@prtcl/plonk-core": "^1.0.0-alpha.2",
+    "@prtcl/plonk-core": "^1.0.0-alpha.3",
     "@prtcl/plonk-hooks": "^1.0.0-alpha.2",
     "@prtcl/plonk-utils": "^1.0.0-alpha.2"
   },


### PR DESCRIPTION
Renames `Env`'s finished method to `done()` to be more in line with iterator syntax